### PR TITLE
Feature/di

### DIFF
--- a/Application.ts
+++ b/Application.ts
@@ -14,7 +14,7 @@ export class Application {
   private app: OakApplication;
 
   public constructor(appConfig: ApplicationConfig) {
-    this.router = new Router();
+    this.router = new Router(appConfig.services);
     this.app = new OakApplication();
 
     for (const controller of appConfig.controllers) {

--- a/Arg.ts
+++ b/Arg.ts
@@ -12,7 +12,7 @@ const defineParameterDecorator = (
   paramKeyRequired?: boolean | undefined,
   paramKey?: string
 ): ParameterDecorator => (
-  target: any,
+  target: Object,
   propertyKey: string | Symbol,
   parameterIndex: number
 ): void => {

--- a/Controller.ts
+++ b/Controller.ts
@@ -2,6 +2,8 @@
 
 import { ControllerMetadata } from "./types.ts";
 import { getControllerOwnMeta, setControllerOwnMeta, defaultMetadata } from "./metadata.ts";
+import {Service} from "./deps.ts"
+
 /**
  * Controller Class decorator responsible for initialising metadata on the controller class.
  * Defines the `prefix` for all subsequent routes defined on the controller.
@@ -12,5 +14,8 @@ export function Controller(prefix: string = "/"): ClassDecorator {
 
     meta.prefix = prefix;
     setControllerOwnMeta(target, meta);
+
+    // Apply Service decorator to class.
+    Service()(target)
   };
 }

--- a/HttpStatus.ts
+++ b/HttpStatus.ts
@@ -2,7 +2,7 @@
 
 import { getControllerMeta, setControllerMeta, defaultMetadata } from "./metadata.ts";
 
-import { ControllerMetadata } from "./types.ts";
+import { ControllerMetadata } from "./types.ts"
 import { Status } from "./deps.ts";
 
 /**

--- a/deps.ts
+++ b/deps.ts
@@ -4,7 +4,16 @@ export {
   Router,
   Application,
   RouterContext,
+  Context,
+  Request,
   Response,
   Middleware,
+  RouteParams,
 } from "https://deno.land/x/oak/mod.ts";
 export { Status, STATUS_TEXT } from "https://deno.land/std/http/http_status.ts";
+export {
+  ServiceCollection,
+  ServiceMultiCollection,
+  Service,
+  Inject,
+} from "https://deno.land/x/di@v0.1.0/mod.ts"

--- a/example/DinosaurController.ts
+++ b/example/DinosaurController.ts
@@ -10,18 +10,21 @@ import {
   Body,
   Query,
   Header,
-  Context,
-  Request,
-  Response,
   HttpStatus,
   BadRequestException,
-  RouterContext,
-  OakRequest,
-  OakResponse,
+  RouterContextService,
+  RequestService,
+  ResponseService,
 } from "./deps.ts";
 
 @Controller("/dinosaur")
 class DinosaurController {
+  constructor(
+    private ctx: RouterContextService,
+    private req: RequestService,
+    private res: ResponseService,
+  ) {}
+
   @Get("/")
   @HttpStatus(200)
   getDinosaurs(@Query("orderBy") orderBy: any, @Query("sort") sort: any) {
@@ -64,13 +67,9 @@ class DinosaurController {
     };
   }
   @Delete("/:id")
-  deleteDinosaur(
-    @Context() ctx: RouterContext,
-    @Request() req: OakRequest,
-    @Response() res: OakResponse
-  ) {
+  deleteDinosaur() {
     return {
-      message: `Deleted dinosaur with id ${ctx.params.id}`,
+      message: `Deleted dinosaur with id ${this.ctx.params.id}`,
     };
   }
 }

--- a/example/deps.ts
+++ b/example/deps.ts
@@ -1,5 +1,8 @@
 // Copyright 2020 Liam Tan. All rights reserved. MIT license.
 
+// For dependency injection to work, you need to import a reflect-metadata polyfill
+import "https://cdn.pika.dev/@abraham/reflection@^0.7.0";
+
 // For your own project, deps.ts should re-export
 // these deps from https://deno.land/x/dactyl/mod.ts
 export {
@@ -20,12 +23,7 @@ export {
   HttpException,
   BadRequestException,
   Application,
+  RouterContextService,
+  RequestService,
+  ResponseService,
 } from "../mod.ts";
-
-// Import this dependency if you wish to typecheck the result
-// of @Context(), @Request, or @Response
-export {
-  RouterContext,
-  Request as OakRequest,
-  Response as OakResponse,
-} from "https://deno.land/x/oak/mod.ts";

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   }

--- a/metadata.ts
+++ b/metadata.ts
@@ -39,20 +39,7 @@ export function setControllerOwnMeta(target: Function, value: ControllerMetadata
  * given updated value
  */
 export function setControllerMeta(target: Object, value: ControllerMetadata): void {
-  setControllerOwnMeta(target.constructor, value);
-}
-/**
- * Helper method that only assigns controller meta if it doesn't
- * exist on the target.
- *
- * Used in `ensureController` to only set
- * default meta if the `@Controller` decorator has not been
- * used on the target yet
- */
-export function setControllerMetaIfNotDefined(target: object, value: ControllerMetadata): void {
-  if (!Reflect.has(target, CONTROLLER_META_PROPKEY)) {
-    setControllerMeta(target, value);
-  }
+  setControllerOwnMeta(target.constructor, value)
 }
 /**
  * Helper method that returns the default metadata object.

--- a/mod.ts
+++ b/mod.ts
@@ -8,3 +8,4 @@ export { HttpException } from "./HttpException.ts";
 export { Param, Body, Query, Header, Context, Request, Response } from "./Arg.ts";
 export { Router } from "./Router.ts";
 export * from "./HttpException.ts";
+export * from "./services.ts"

--- a/services.ts
+++ b/services.ts
@@ -1,0 +1,23 @@
+import {
+  RouterContext as OakRouterContext,
+  Context,
+  Router,
+  Request,
+  Response,
+  RouteParams,
+} from "./deps.ts"
+
+// These provide proper type inference for both the dependency injector and the
+// controllers.
+
+export abstract class RouterContextService<
+  P extends RouteParams = RouteParams,
+  S extends Record<string | number | symbol, any> = Record<string, any>,
+> extends Context<S> implements OakRouterContext<P>  {
+  abstract params: P;
+  abstract router: Router;
+}
+
+export abstract class RequestService extends Request {}
+
+export abstract class ResponseService extends Response {}

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,5 @@
 // Copyright 2020 Liam Tan. All rights reserved. MIT license.
+import { ServiceCollection } from "./deps.ts";
 
 export enum HttpMethod {
   GET = "get",
@@ -62,12 +63,7 @@ export interface RouteArgument {
 
 export interface ApplicationConfig {
   controllers: Array<Newable<any>>;
-}
-/**
- * Definition for a class.
- */
-export interface Newable<T> {
-  new (...args: any[]): T;
+  services?: ServiceCollection,
 }
 /**
  * Definition for a class.

--- a/types.ts
+++ b/types.ts
@@ -69,3 +69,9 @@ export interface ApplicationConfig {
 export interface Newable<T> {
   new (...args: any[]): T;
 }
+/**
+ * Definition for a class.
+ */
+export interface Newable<T> {
+  new (...args: any[]): T
+}


### PR DESCRIPTION
I've added dependency injection to the framework using the [deno.land/x/di](https://deno.land/x/di) module. It now creates an instance of the controller for each request, which allows the controller to depend on request-specific services in its constructor (e.g. Context). I've also added a mechanism that allows you to add custom services to the app.

I did adjust the decorators a bit to clear up how metadata is being added and retrieved, since the controller is only constructed upon a request (after you ask for the metadata). Not sure if it was completely necessary, but the typings were improved a bit and it's a little more readable where metadata is going.

For the Context, Request, and Response objects, I've added custom abstract classes for the dependency injector. This allows controllers to use them for both typing and injection, removing the need to use custom identifiers for them. (RequestContext is an interface, not a class, so it couldn't be used as an identifier. To make things consistent, I just used abstract classes for all of the objects, and it allows extensions later).

As an aside, it might be worth running `deno fmt` on the module for consistency (I noticed my auto-format would rewrite code and had to turn it off). If wanted, I can add also a GitHub Workflow for CI (I have a config that I use for Deno that should work well) (in a different PR ideally).