### PR TITLE
Support mapping whole query/body to method parameters

### DIFF
--- a/Arg.ts
+++ b/Arg.ts
@@ -25,7 +25,7 @@ export const defineParameterDecorator = (
 
     meta.args.push({
       type: argType,
-      key: paramKey || "",
+      key: paramKey,
       index: parameterIndex,
       argFor: propertyKey,
     });
@@ -41,7 +41,7 @@ export const defineParameterDecorator = (
  * public controllerAction(@Param('id') id: number): any {}
  * ```
  */
-export function Param(paramKey: string): ParameterDecorator {
+export function Param(paramKey?: string): ParameterDecorator {
   return defineParameterDecorator(ArgsType.PARAM, paramKey);
 }
 /**
@@ -80,7 +80,7 @@ export function Query(queryKey?: string): ParameterDecorator {
  * public controllerAction(@Header('content-type') contentType: string): any { }
  * ```
  */
-export function Header(headerKey: string): ParameterDecorator {
+export function Header(headerKey?: string): ParameterDecorator {
   return defineParameterDecorator(ArgsType.HEADER, headerKey);
 }
 /**

--- a/Arg.ts
+++ b/Arg.ts
@@ -51,8 +51,11 @@ export function Param(paramKey: string): ParameterDecorator {
  * ```ts
  * public controllerAction(@Body('name') name: string): any { }
  * ```
+ *
+ * When bodyKey is not specified, it maps the whole body, else the specified
+ * field
  */
-export function Body(bodyKey: string): ParameterDecorator {
+export function Body(bodyKey?: string): ParameterDecorator {
   return defineParameterDecorator(ArgsType.BODY, bodyKey);
 }
 /**
@@ -62,8 +65,11 @@ export function Body(bodyKey: string): ParameterDecorator {
  * ```ts
  * public controllerAction(@Query('orderBy') orderBy: string): any { }
  * ```
+ *
+ * When queryKey is not specified, it maps the whole body, else the specified
+ * field
  */
-export function Query(queryKey: string): ParameterDecorator {
+export function Query(queryKey?: string): ParameterDecorator {
   return defineParameterDecorator(ArgsType.QUERY, queryKey);
 }
 /**

--- a/Router.ts
+++ b/Router.ts
@@ -87,6 +87,8 @@ ______           _         _
               context
             );
 
+            console.log(meta.args, routeArgs);
+
             // call controller action here. Provide arguments injected via parameter
             // decorator function metadata
             const response: any = await instance[route.methodName as string](...routeArgs);
@@ -188,7 +190,11 @@ ______           _         _
     return filteredArguments.map((arg: RouteArgument): any => {
       switch (arg.type) {
         case ArgsType.PARAM:
-          return params[arg.key];
+          if (arg.key === undefined) {
+            return params;
+          } else {
+            return params[arg.key];
+          }
         case ArgsType.BODY:
           if (arg.key === undefined) {
             return body.value;
@@ -202,7 +208,11 @@ ______           _         _
             return query[arg.key];
           }
         case ArgsType.HEADER:
-          return headers[arg.key];
+          if (arg.key === undefined) {
+            return headers;
+          } else {
+            return headers[arg.key];
+          }
         case ArgsType.CONTEXT:
           return context;
         case ArgsType.REQUEST:

--- a/Router.ts
+++ b/Router.ts
@@ -190,9 +190,17 @@ ______           _         _
         case ArgsType.PARAM:
           return params[arg.key];
         case ArgsType.BODY:
-          return body.value[arg.key];
+          if (arg.key === undefined) {
+            return body.value;
+          } else {
+            return body.value[arg.key];
+          }
         case ArgsType.QUERY:
-          return query[arg.key];
+          if (arg.key === undefined) {
+            return query;
+          } else {
+            return query[arg.key];
+          }
         case ArgsType.HEADER:
           return headers[arg.key];
         case ArgsType.CONTEXT:

--- a/types.ts
+++ b/types.ts
@@ -53,7 +53,7 @@ export interface RouteDefinition {
 export interface RouteArgument {
   type: ArgsType;
   index: number;
-  key: string;
+  key?: string;
   argFor: string | Symbol;
 }
 /**


### PR DESCRIPTION
It's kinda a feature request.

This PR adds supports for the following syntax:

```typescript
@Controller("/dinosaur")
class DinosaurController {
  @Get("/")
  @HttpStatus(200)
  getDinosaurs(@Query() query: {orderBy: any, sort: any}) {
    const {orderBy, sort} = any;

    if (orderBy) {
      dinosaurs.sort((a: any, b: any) => (a[orderBy] < b[orderBy] ? -1 : 1));
      if (sort === "desc") dinosaurs.reverse();
    }

    return {
      message: "Action returning all dinosaurs! Defaults to 200 status!",
      data: dinosaurs,
    };
  }
}
```

Allows a method to check for dynamic fields and/or whether are there any unexpected fields specified without the complexity of using the whole context.

My other idea was to support annotating with `@Body` / `@Query` (without parentheses), but that seems less maintainable. Also there exists `@Context()`, `@Request()`, `@Response()`.

PS.: Not tested, see https://github.com/liamtan28/dactyl/issues/8
<br>Types seem OK.